### PR TITLE
initialize node_array before comparison

### DIFF
--- a/rmw_microxrcedds_c/src/rmw_wait.c
+++ b/rmw_microxrcedds_c/src/rmw_wait.c
@@ -81,8 +81,7 @@ rmw_wait(
   rmw_ret_t ret = RMW_RET_OK;
 
   //Look for every node configured in the wait set
-  CustomNode * node_array[RMW_UXRCE_MAX_NODES];
-  memset(node_array, RMW_UXRCE_MAX_NODES, sizeof(CustomNode*));
+  CustomNode * node_array[RMW_UXRCE_MAX_NODES] = { NULL };
   size_t node_array_index = 0;
 
   for (size_t i = 0; i < services->service_count; i++){

--- a/rmw_microxrcedds_c/src/rmw_wait.c
+++ b/rmw_microxrcedds_c/src/rmw_wait.c
@@ -82,6 +82,7 @@ rmw_wait(
 
   //Look for every node configured in the wait set
   CustomNode * node_array[RMW_UXRCE_MAX_NODES];
+  memset(node_array, RMW_UXRCE_MAX_NODES, sizeof(CustomNode*));
   size_t node_array_index = 0;
 
   for (size_t i = 0; i < services->service_count; i++){


### PR DESCRIPTION
This init doesn't seem to be strictly necessary, since only initialized indexes will be used, but my compiler complains otherwise. It won't hurt either.