### PR TITLE
Feture/bug fix

### DIFF
--- a/rmw_microxrcedds_c/CMakeLists.txt
+++ b/rmw_microxrcedds_c/CMakeLists.txt
@@ -180,8 +180,6 @@ target_compile_options(${PROJECT_NAME}
     $<$<C_COMPILER_ID:GNU>:-Werror-implicit-function-declaration>
     $<$<C_COMPILER_ID:GNU>:$<$<VERSION_GREATER:$<C_COMPILER_VERSION>,8.1>:-Wcast-align=strict>>
     $<$<C_COMPILER_ID:GNU>:-Wvla>
-    $<$<C_COMPILER_ID:GNU>:-Werror>
-    $<$<C_COMPILER_ID:GNU>:-pedantic-errors>
     $<$<C_COMPILER_ID:MSVC>:/Wall>
   )
 

--- a/rmw_microxrcedds_c/src/identifiers.h
+++ b/rmw_microxrcedds_c/src/identifiers.h
@@ -15,7 +15,7 @@
 #ifndef IDENTIFIERS_H_
 #define IDENTIFIERS_H_
 
-const char * const eprosima_microxrcedds_identifier;
-const char * const eprosima_microxrcedds_serialization_format;
+extern const char * const eprosima_microxrcedds_identifier;
+extern const char * const eprosima_microxrcedds_serialization_format;
 
 #endif  // IDENTIFIERS_H_

--- a/rmw_microxrcedds_c/src/rmw_init.c
+++ b/rmw_microxrcedds_c/src/rmw_init.c
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <time.h>
-
 #include "./types.h"
 #include "./rmw_microxrcedds_c/rmw_c_macros.h"
 #include "./rmw_node.h"
@@ -65,9 +63,6 @@ rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t all
   }
 #endif
 
-  time_t t;
-  time(&t);
-  srand((unsigned)t);
   init_options->impl->connection_params.client_key = rand();
 
   return RMW_RET_OK;


### PR DESCRIPTION
This PR fix some building issues (-Werror), declares RMW identifiers as extern in order to not have duplicated symbols at linking time and removes the random seeding process from the RMW layer.