### PR TITLE
Fix id_gen

### DIFF
--- a/rmw_microxrcedds_c/src/rmw_client.c
+++ b/rmw_microxrcedds_c/src/rmw_client.c
@@ -107,7 +107,7 @@ rmw_create_client(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_client->client_id = uxr_object_id(custom_node->context->id_gen++, UXR_REQUESTER_ID);
+    custom_client->client_id = uxr_object_id(custom_node->context->id_requester++, UXR_REQUESTER_ID);
 
     memset(custom_client->client_gid.data, 0, RMW_GID_STORAGE_SIZE);
     memcpy(custom_client->client_gid.data, &custom_client->client_id,

--- a/rmw_microxrcedds_c/src/rmw_client.c
+++ b/rmw_microxrcedds_c/src/rmw_client.c
@@ -107,7 +107,7 @@ rmw_create_client(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_client->client_id = uxr_object_id(custom_node->id_gen++, UXR_REQUESTER_ID);
+    custom_client->client_id = uxr_object_id(custom_node->context->id_gen++, UXR_REQUESTER_ID);
 
     memset(custom_client->client_gid.data, 0, RMW_GID_STORAGE_SIZE);
     memcpy(custom_client->client_gid.data, &custom_client->client_id,

--- a/rmw_microxrcedds_c/src/rmw_init.c
+++ b/rmw_microxrcedds_c/src/rmw_init.c
@@ -156,6 +156,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   #endif
 
   context_impl->connection_params.client_key = options->impl->connection_params.client_key;
+  context_impl->id_gen = 1;
 
   context->impl = context_impl;
 

--- a/rmw_microxrcedds_c/src/rmw_init.c
+++ b/rmw_microxrcedds_c/src/rmw_init.c
@@ -156,7 +156,15 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   #endif
 
   context_impl->connection_params.client_key = options->impl->connection_params.client_key;
-  context_impl->id_gen = 1;
+
+  context_impl->id_participant = 0;
+  context_impl->id_topic = 0;
+  context_impl->id_publisher = 0;
+  context_impl->id_datawriter = 0;
+  context_impl->id_subscriber = 0;
+  context_impl->id_datareader = 0;
+  context_impl->id_requester = 0;
+  context_impl->id_replier = 0;
 
   context->impl = context_impl;
 

--- a/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
+++ b/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
@@ -71,7 +71,7 @@ create_topic(
 
 
   // Generate topic id
-  custom_topic_ptr->topic_id = uxr_object_id(custom_node->id_gen++, UXR_TOPIC_ID);
+  custom_topic_ptr->topic_id = uxr_object_id(custom_node->context->id_gen++, UXR_TOPIC_ID);
 
 #ifdef MICRO_XRCEDDS_USE_XML
   char xml_buffer[RMW_UXRCE_XML_BUFFER_LENGTH];

--- a/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
+++ b/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
@@ -71,7 +71,7 @@ create_topic(
 
 
   // Generate topic id
-  custom_topic_ptr->topic_id = uxr_object_id(custom_node->context->id_gen++, UXR_TOPIC_ID);
+  custom_topic_ptr->topic_id = uxr_object_id(custom_node->context->id_topic++, UXR_TOPIC_ID);
 
 #ifdef MICRO_XRCEDDS_USE_XML
   char xml_buffer[RMW_UXRCE_XML_BUFFER_LENGTH];

--- a/rmw_microxrcedds_c/src/rmw_node.c
+++ b/rmw_microxrcedds_c/src/rmw_node.c
@@ -72,7 +72,7 @@ rmw_node_t * create_node(const char * name, const char * namespace_, size_t doma
   }
   memcpy((char *)node_handle->namespace_, namespace_, strlen(namespace_) + 1);
 
-  node_info->participant_id = uxr_object_id(node_info->context->id_gen++, UXR_PARTICIPANT_ID);
+  node_info->participant_id = uxr_object_id(node_info->context->id_participant++, UXR_PARTICIPANT_ID);
   uint16_t participant_req;
 #ifdef MICRO_XRCEDDS_USE_XML
   char participant_xml[RMW_UXRCE_XML_BUFFER_LENGTH];

--- a/rmw_microxrcedds_c/src/rmw_node.c
+++ b/rmw_microxrcedds_c/src/rmw_node.c
@@ -72,7 +72,7 @@ rmw_node_t * create_node(const char * name, const char * namespace_, size_t doma
   }
   memcpy((char *)node_handle->namespace_, namespace_, strlen(namespace_) + 1);
 
-  node_info->participant_id = uxr_object_id(node_info->id_gen++, UXR_PARTICIPANT_ID);
+  node_info->participant_id = uxr_object_id(node_info->context->id_gen++, UXR_PARTICIPANT_ID);
   uint16_t participant_req;
 #ifdef MICRO_XRCEDDS_USE_XML
   char participant_xml[RMW_UXRCE_XML_BUFFER_LENGTH];

--- a/rmw_microxrcedds_c/src/rmw_publisher.c
+++ b/rmw_microxrcedds_c/src/rmw_publisher.c
@@ -139,7 +139,7 @@ rmw_create_publisher(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
   #endif
 
-    custom_publisher->publisher_id = uxr_object_id(custom_node->id_gen++, UXR_PUBLISHER_ID);
+    custom_publisher->publisher_id = uxr_object_id(custom_node->context->id_gen++, UXR_PUBLISHER_ID);
     uint16_t publisher_req;
   #ifdef MICRO_XRCEDDS_USE_XML
     char publisher_name[20];
@@ -161,7 +161,7 @@ rmw_create_publisher(
       custom_node->participant_id, "", UXR_REPLACE);
   #endif
 
-    custom_publisher->datawriter_id = uxr_object_id(custom_node->id_gen++, UXR_DATAWRITER_ID);
+    custom_publisher->datawriter_id = uxr_object_id(custom_node->context->id_gen++, UXR_DATAWRITER_ID);
     uint16_t datawriter_req;
   #ifdef MICRO_XRCEDDS_USE_XML
     if (!build_datawriter_xml(topic_name, custom_publisher->type_support_callbacks,

--- a/rmw_microxrcedds_c/src/rmw_publisher.c
+++ b/rmw_microxrcedds_c/src/rmw_publisher.c
@@ -139,7 +139,7 @@ rmw_create_publisher(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
   #endif
 
-    custom_publisher->publisher_id = uxr_object_id(custom_node->context->id_gen++, UXR_PUBLISHER_ID);
+    custom_publisher->publisher_id = uxr_object_id(custom_node->context->id_publisher++, UXR_PUBLISHER_ID);
     uint16_t publisher_req;
   #ifdef MICRO_XRCEDDS_USE_XML
     char publisher_name[20];
@@ -161,7 +161,7 @@ rmw_create_publisher(
       custom_node->participant_id, "", UXR_REPLACE);
   #endif
 
-    custom_publisher->datawriter_id = uxr_object_id(custom_node->context->id_gen++, UXR_DATAWRITER_ID);
+    custom_publisher->datawriter_id = uxr_object_id(custom_node->context->id_datawriter++, UXR_DATAWRITER_ID);
     uint16_t datawriter_req;
   #ifdef MICRO_XRCEDDS_USE_XML
     if (!build_datawriter_xml(topic_name, custom_publisher->type_support_callbacks,

--- a/rmw_microxrcedds_c/src/rmw_service.c
+++ b/rmw_microxrcedds_c/src/rmw_service.c
@@ -107,7 +107,7 @@ rmw_create_service(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_service->service_id = uxr_object_id(custom_node->id_gen++, UXR_REPLIER_ID);
+    custom_service->service_id = uxr_object_id(custom_node->context->id_gen++, UXR_REPLIER_ID);
 
     memset(custom_service->service_gid.data, 0, RMW_GID_STORAGE_SIZE);
     memcpy(custom_service->service_gid.data, &custom_service->service_id,

--- a/rmw_microxrcedds_c/src/rmw_service.c
+++ b/rmw_microxrcedds_c/src/rmw_service.c
@@ -107,7 +107,7 @@ rmw_create_service(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_service->service_id = uxr_object_id(custom_node->context->id_gen++, UXR_REPLIER_ID);
+    custom_service->service_id = uxr_object_id(custom_node->context->id_replier++, UXR_REPLIER_ID);
 
     memset(custom_service->service_gid.data, 0, RMW_GID_STORAGE_SIZE);
     memcpy(custom_service->service_gid.data, &custom_service->service_id,

--- a/rmw_microxrcedds_c/src/rmw_subscription.c
+++ b/rmw_microxrcedds_c/src/rmw_subscription.c
@@ -143,7 +143,7 @@ rmw_create_subscription(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_subscription->subscriber_id = uxr_object_id(custom_node->id_gen++, UXR_SUBSCRIBER_ID);
+    custom_subscription->subscriber_id = uxr_object_id(custom_node->context->id_gen++, UXR_SUBSCRIBER_ID);
     uint16_t subscriber_req;
 #ifdef MICRO_XRCEDDS_USE_XML
     char subscriber_name[20];
@@ -164,7 +164,7 @@ rmw_create_subscription(
 #endif
 
 
-    custom_subscription->datareader_id = uxr_object_id(custom_node->id_gen++, UXR_DATAREADER_ID);
+    custom_subscription->datareader_id = uxr_object_id(custom_node->context->id_gen++, UXR_DATAREADER_ID);
     uint16_t datareader_req;
 #ifdef MICRO_XRCEDDS_USE_XML
     if (!build_datareader_xml(topic_name, custom_subscription->type_support_callbacks,

--- a/rmw_microxrcedds_c/src/rmw_subscription.c
+++ b/rmw_microxrcedds_c/src/rmw_subscription.c
@@ -143,7 +143,7 @@ rmw_create_subscription(
     char profile_name[RMW_UXRCE_REF_BUFFER_LENGTH];
 #endif
 
-    custom_subscription->subscriber_id = uxr_object_id(custom_node->context->id_gen++, UXR_SUBSCRIBER_ID);
+    custom_subscription->subscriber_id = uxr_object_id(custom_node->context->id_subscriber++, UXR_SUBSCRIBER_ID);
     uint16_t subscriber_req;
 #ifdef MICRO_XRCEDDS_USE_XML
     char subscriber_name[20];
@@ -164,7 +164,7 @@ rmw_create_subscription(
 #endif
 
 
-    custom_subscription->datareader_id = uxr_object_id(custom_node->context->id_gen++, UXR_DATAREADER_ID);
+    custom_subscription->datareader_id = uxr_object_id(custom_node->context->id_datareader++, UXR_DATAREADER_ID);
     uint16_t datareader_req;
 #ifdef MICRO_XRCEDDS_USE_XML
     if (!build_datareader_xml(topic_name, custom_subscription->type_support_callbacks,

--- a/rmw_microxrcedds_c/src/types.h
+++ b/rmw_microxrcedds_c/src/types.h
@@ -73,6 +73,8 @@ struct  rmw_context_impl_t
   uint8_t input_reliable_stream_buffer[RMW_UXRCE_MAX_BUFFER_SIZE];
   uint8_t output_reliable_stream_buffer[RMW_UXRCE_MAX_BUFFER_SIZE];
   uint8_t output_best_effort_stream_buffer[RMW_UXRCE_MAX_TRANSPORT_MTU];
+
+  uint16_t id_gen;
 };
 
 struct  rmw_init_options_impl_t
@@ -193,7 +195,6 @@ typedef struct rmw_uxrce_node_t
 
   uxrObjectId participant_id;
   rmw_uxrce_topic_t * custom_topic_sp;
-  uint16_t id_gen;
 } rmw_uxrce_node_t;
 
 // Static memory pools

--- a/rmw_microxrcedds_c/src/types.h
+++ b/rmw_microxrcedds_c/src/types.h
@@ -74,7 +74,14 @@ struct  rmw_context_impl_t
   uint8_t output_reliable_stream_buffer[RMW_UXRCE_MAX_BUFFER_SIZE];
   uint8_t output_best_effort_stream_buffer[RMW_UXRCE_MAX_TRANSPORT_MTU];
 
-  uint16_t id_gen;
+  uint16_t id_participant;
+  uint16_t id_topic;
+  uint16_t id_publisher;
+  uint16_t id_datawriter;
+  uint16_t id_subscriber;
+  uint16_t id_datareader;
+  uint16_t id_requester;
+  uint16_t id_replier;
 };
 
 struct  rmw_init_options_impl_t


### PR DESCRIPTION
This PR fixes a bug when multiple participants were created in the same session. The variable id_gen was related to participants instead of a session (or context), so they were repeated, and the agent destroyed the repeated objects.

Related to https://github.com/micro-ROS/zephyr_apps/issues/3