### PR TITLE
Fix wait return code

### DIFF
--- a/rmw_microxrcedds_c/src/rmw_wait.c
+++ b/rmw_microxrcedds_c/src/rmw_wait.c
@@ -143,6 +143,5 @@ rmw_wait(
 
   EPROS_PRINT_TRACE()
     
-  return  (buffered_status) ? RMW_RET_OK : 
-          ((run_session_status) ? RMW_RET_ERROR : RMW_RET_TIMEOUT);
+  return  (buffered_status) ? RMW_RET_OK : RMW_RET_TIMEOUT;
 }

--- a/rmw_microxrcedds_c/src/rmw_wait.c
+++ b/rmw_microxrcedds_c/src/rmw_wait.c
@@ -99,7 +99,7 @@ rmw_wait(
     session = &custom_subscription->owner_node->context->session;
   }
 
-  bool run_session_status = uxr_run_session_until_timeout(session, timeout);
+  uxr_run_session_until_timeout(session, timeout);
   bool buffered_status = false;
 
   // Check services


### PR DESCRIPTION
This PR fixes the return code in `rmw_wait()`. We were relying on the fact that when `uxr_run_session_until_timeout(session, timeout)` returns `true` means that a subscription (or similar) has arrived but it returns true if any XRCE message arrives. 

So, related to this comment: https://github.com/micro-ROS/rmw-microxrcedds/pull/61#issuecomment-621849862: we are returning `RMW_RET_ERROR` when there are no micro-ROS objects in queue and any XRCE message has arrived.