### PR TITLE
Fix somes compilation warnings

### DIFF
--- a/rmw_microxrcedds_c/src/rmw_init.c
+++ b/rmw_microxrcedds_c/src/rmw_init.c
@@ -26,7 +26,7 @@
 
 #include "./callbacks.h"
 
-#ifdef MICRO_XRCEDDS_SERIAL || defined(MICRO_XRCEDDS_CUSTOM_SERIAL)
+#if defined(MICRO_XRCEDDS_SERIAL) || defined(MICRO_XRCEDDS_CUSTOM_SERIAL)
 #define CLOSE_TRANSPORT(transport) uxr_close_serial_transport(transport)
 #elif defined(MICRO_XRCEDDS_UDP)
 #define CLOSE_TRANSPORT(transport) uxr_close_udp_transport(transport)
@@ -34,6 +34,9 @@
 #define CLOSE_TRANSPORT(transport)
 #endif
 
+/* Variables definition to fix compiler warnings */
+
+#define NANOSEC_TO_SEC 1000000000UL
 
 rmw_ret_t
 rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t allocator)
@@ -77,7 +80,7 @@ rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t all
 
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);
-  srand((ts.tv_sec * 1000000000UL ) + ts.tv_nsec);
+  srand((ts.tv_sec * NANOSEC_TO_SEC) + ts.tv_nsec);
 
   do {
     init_options->impl->connection_params.client_key = rand();
@@ -224,7 +227,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
           &context_impl->serial_platform, fd, 0, 1))
         {
           RMW_SET_ERROR_MSG("Can not create an serial connection");
-          return NULL;
+          return (rmw_ret_t) NULL;
         }
       }
     }

--- a/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
+++ b/rmw_microxrcedds_c/src/rmw_microxrcedds_topic.c
@@ -80,7 +80,7 @@ create_topic(
 #endif
 
   // Generate request
-  uint16_t topic_req;
+  uint16_t topic_req = 0;
 #ifdef MICRO_XRCEDDS_USE_XML
   if (!build_topic_xml(topic_name, message_type_support_callbacks,
     qos_policies, xml_buffer, sizeof(xml_buffer)))

--- a/rmw_microxrcedds_c/src/rmw_node.c
+++ b/rmw_microxrcedds_c/src/rmw_node.c
@@ -31,6 +31,10 @@
 #include "./types.h"
 #include "./utils.h"
 
+/* Variables definition to fix compiler warnings */
+
+#define TIMEOUT_IN_MS       1000
+
 rmw_node_t * create_node(const char * name, const char * namespace_, size_t domain_id, const rmw_context_t * context)
 {
   if (!context) {
@@ -73,7 +77,7 @@ rmw_node_t * create_node(const char * name, const char * namespace_, size_t doma
   memcpy((char *)node_handle->namespace_, namespace_, strlen(namespace_) + 1);
 
   node_info->participant_id = uxr_object_id(node_info->context->id_participant++, UXR_PARTICIPANT_ID);
-  uint16_t participant_req;
+  uint16_t participant_req = 0;
 #ifdef MICRO_XRCEDDS_USE_XML
   char participant_xml[RMW_UXRCE_XML_BUFFER_LENGTH];
   if (!build_participant_xml(domain_id, name, participant_xml, sizeof(participant_xml))) {
@@ -100,7 +104,7 @@ rmw_node_t * create_node(const char * name, const char * namespace_, size_t doma
   uint8_t status[1];
   uint16_t requests[] = {participant_req};
 
-  if (!uxr_run_session_until_all_status(&node_info->context->session, 1000, requests, status, 1)) {
+  if (!uxr_run_session_until_all_status(&node_info->context->session, TIMEOUT_IN_MS, requests, status, 1)) {
     uxr_delete_session(&node_info->context->session);
     rmw_uxrce_fini_node_memory(node_handle);
     RMW_SET_ERROR_MSG("Issues creating micro XRCE-DDS entities");

--- a/rmw_microxrcedds_c/src/rmw_publish.c
+++ b/rmw_microxrcedds_c/src/rmw_publish.c
@@ -18,6 +18,10 @@
 #include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 
+/* Variables definition to fix compiler warnings */
+
+#define TIMEOUT_IN_MS    1000
+
 rmw_ret_t
 rmw_publish(
   const rmw_publisher_t * publisher,
@@ -55,7 +59,8 @@ rmw_publish(
       if (UXR_BEST_EFFORT_STREAM == custom_publisher->stream_id.type){
         uxr_flash_output_streams(&custom_publisher->owner_node->context->session);
       }else{
-        written &= uxr_run_session_until_confirm_delivery(&custom_publisher->owner_node->context->session, 1000);
+        written &= uxr_run_session_until_confirm_delivery(&custom_publisher->owner_node->context->session,
+                                                          TIMEOUT_IN_MS);
       }
     }
     if (!written) {

--- a/rmw_microxrcedds_c/src/rmw_publisher.c
+++ b/rmw_microxrcedds_c/src/rmw_publisher.c
@@ -29,6 +29,11 @@
 #include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 
+/* Variables definition to fix compiler warnings */
+
+#define PUBR_MAX_NAME    20
+#define TIMEOUT_IN_MS    1000
+
 rmw_ret_t
 rmw_init_publisher_allocation(
   const rosidl_message_type_support_t * type_support,
@@ -142,7 +147,7 @@ rmw_create_publisher(
     custom_publisher->publisher_id = uxr_object_id(custom_node->context->id_publisher++, UXR_PUBLISHER_ID);
     uint16_t publisher_req;
   #ifdef MICRO_XRCEDDS_USE_XML
-    char publisher_name[20];
+    char publisher_name[PUBR_MAX_NAME];
     generate_name(&custom_publisher->publisher_id, publisher_name, sizeof(publisher_name));
     if (!build_publisher_xml(publisher_name, xml_buffer, sizeof(xml_buffer))) {
       RMW_SET_ERROR_MSG("failed to generate xml request for publisher creation");

--- a/rmw_microxrcedds_c/src/rmw_request.c
+++ b/rmw_microxrcedds_c/src/rmw_request.c
@@ -17,6 +17,10 @@
 #include <rmw/rmw.h>
 #include <rmw/error_handling.h>
 
+/* Variables definition to fix compiler warnings */
+
+#define TIMEOUT_IN_MS    100
+
 rmw_ret_t
 rmw_send_request(
   const rmw_client_t * client,
@@ -52,7 +56,7 @@ rmw_send_request(
     return RMW_RET_ERROR;
   }
 
-  uxr_run_session_time(&custom_node->context->session,100);
+  uxr_run_session_time(&custom_node->context->session, TIMEOUT_IN_MS);
 
   return RMW_RET_OK;
 }

--- a/rmw_microxrcedds_c/src/rmw_service.c
+++ b/rmw_microxrcedds_c/src/rmw_service.c
@@ -27,6 +27,11 @@
 
 #include "./utils.h"
 
+/* Variables definition to fix compiler warnings */
+
+#define SERVICE_MAX_NAME    20
+#define TIMEOUT_IN_MS       1000
+
 rmw_service_t *
 rmw_create_service(
   const rmw_node_t * node,
@@ -115,7 +120,7 @@ rmw_create_service(
 
     uint16_t service_req;
 #ifdef MICRO_XRCEDDS_USE_XML
-    char service_name_id[20];
+    char service_name_id[SERVICE_MAX_NAME];
     generate_name(&custom_service->service_id, service_name_id, sizeof(service_name_id));
     if (!build_service_xml(service_name_id, service_name, false, custom_service->type_support_callbacks, qos_policies, xml_buffer, sizeof(xml_buffer))) {
       RMW_SET_ERROR_MSG("failed to generate xml request for service creation");

--- a/rmw_microxrcedds_c/src/rmw_subscription.c
+++ b/rmw_microxrcedds_c/src/rmw_subscription.c
@@ -27,6 +27,11 @@
 #include <rmw/types.h>
 #include <rmw/allocators.h>
 
+/* Variables definition to fix compiler warnings */
+
+#define SUB_MAX_NAME    20
+#define TIMEOUT_IN_MS    1000
+
 rmw_ret_t
 rmw_init_subscription_allocation(
   const rosidl_message_type_support_t * type_support,
@@ -146,7 +151,7 @@ rmw_create_subscription(
     custom_subscription->subscriber_id = uxr_object_id(custom_node->context->id_subscriber++, UXR_SUBSCRIBER_ID);
     uint16_t subscriber_req;
 #ifdef MICRO_XRCEDDS_USE_XML
-    char subscriber_name[20];
+    char subscriber_name[SUB_MAX_NAME];
     generate_name(&custom_subscription->subscriber_id, subscriber_name, sizeof(subscriber_name));
     if (!build_subscriber_xml(subscriber_name, xml_buffer, sizeof(xml_buffer))) {
       RMW_SET_ERROR_MSG("failed to generate xml request for subscriber creation");
@@ -165,7 +170,7 @@ rmw_create_subscription(
 
 
     custom_subscription->datareader_id = uxr_object_id(custom_node->context->id_datareader++, UXR_DATAREADER_ID);
-    uint16_t datareader_req;
+    uint16_t datareader_req = 0;
 #ifdef MICRO_XRCEDDS_USE_XML
     if (!build_datareader_xml(topic_name, custom_subscription->type_support_callbacks,
       qos_policies, xml_buffer,

--- a/rmw_microxrcedds_c/src/rmw_wait.c
+++ b/rmw_microxrcedds_c/src/rmw_wait.c
@@ -20,6 +20,12 @@
 #include <limits.h>
 #include <math.h>
 
+/* Variables definition to fix compiler warnings */
+
+#define TIMEOUT_IN_MS    1000
+#define MILISEC_TO_SEC   1000
+#define NANOSEC_TO_MS    1000000
+
 rmw_ret_t
 rmw_wait(
   rmw_subscriptions_t * subscriptions,
@@ -40,13 +46,13 @@ rmw_wait(
   uint64_t timeout;
   if (wait_timeout != NULL) {
     // Convert to int (checking overflow)
-    if (wait_timeout->sec >= (UINT64_MAX / 1000)) {
+    if (wait_timeout->sec >= (UINT64_MAX / MILISEC_TO_SEC)) {
       // Overflow
       timeout = INT_MAX;
       RMW_SET_ERROR_MSG("Wait timeout overflow");
     } else {
-      timeout = wait_timeout->sec * 1000;
-      uint64_t timeout_ms = wait_timeout->nsec / 1000000;
+      timeout = wait_timeout->sec * MILISEC_TO_SEC;
+      uint64_t timeout_ms = wait_timeout->nsec / NANOSEC_TO_MS;
       if ((UINT64_MAX - timeout) <= timeout_ms) {
         // Overflow
         timeout = INT_MAX;


### PR DESCRIPTION
I thought about the idea of moving TIMEOUT_IN_MS and other definitions to rmw/rmw.h, but noticed that it is not always equal to 1000. Also this way the value could be modified locally without affecting all files.