### PR TITLE
Add agent check status functionality

### DIFF
--- a/rmw_microxrcedds_c/include/rmw_uros/options.h
+++ b/rmw_microxrcedds_c/include/rmw_uros/options.h
@@ -80,6 +80,15 @@ rmw_ret_t rmw_uros_discover_agent(rmw_init_options_t * rmw_options);
  */
 rmw_ret_t rmw_uros_options_set_client_key(uint32_t client_key, rmw_init_options_t * rmw_options);
 
+/**
+ * \brief Check if micro-ROS Agent answers to micro-ROS client
+ *
+ * \param[in] timeout_ms timeout in ms.
+ * \return RMW_RET_OK If micro-ROS Agent is available.
+ * \return RMW_RET_ERROR If micro-ROS Agent is not available.
+ */
+rmw_ret_t rmw_uros_check_agent_status(int timeout_ms);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/rmw_microxrcedds_c/src/rmw_uros_options.c
+++ b/rmw_microxrcedds_c/src/rmw_uros_options.c
@@ -186,7 +186,7 @@ rmw_ret_t rmw_uros_options_set_client_key(uint32_t client_key, rmw_init_options_
 rmw_ret_t rmw_uros_check_agent_status(int timeout_ms)
 {  
   bool synchronized = true;
-  rmw_uxrce_mempool_item_t * item = session_memory.allocateditems;
+  struct rmw_uxrce_mempool_item_t * item = session_memory.allocateditems;
   while (item != NULL) {
     rmw_context_impl_t * context = (rmw_context_impl_t *) item->data;
     synchronized &= uxr_sync_session(&context->session, timeout_ms);

--- a/rmw_microxrcedds_c/src/rmw_uros_options.c
+++ b/rmw_microxrcedds_c/src/rmw_uros_options.c
@@ -182,3 +182,15 @@ rmw_ret_t rmw_uros_options_set_client_key(uint32_t client_key, rmw_init_options_
 
   return RMW_RET_OK;
 }
+
+rmw_ret_t rmw_uros_check_agent_status(int timeout_ms)
+{  
+  bool synchronized = true;
+  rmw_uxrce_mempool_item_t * item = session_memory.allocateditems;
+  while (item != NULL) {
+    rmw_context_impl_t * context = (rmw_context_impl_t *) item->data;
+    synchronized &= uxr_sync_session(&context->session, timeout_ms);
+    item = item->next;
+  }
+  return (synchronized && session_memory.allocateditems != NULL) ? RMW_RET_OK : RMW_RET_ERROR;
+}

--- a/rmw_microxrcedds_c/test/test_rmw.cpp
+++ b/rmw_microxrcedds_c/test/test_rmw.cpp
@@ -42,3 +42,19 @@ TEST(rmw_microxrcedds, autodiscover) {
   ASSERT_EQ(rmw_init(&test_options, &test_context), RMW_RET_OK);
   ASSERT_EQ(rmw_shutdown(&test_context), RMW_RET_OK);
 }
+
+/*
+   Testing rmw agent check.
+*/
+TEST(rmw_microxrcedds, agent_chec_status) {
+  rmw_context_t test_context = rmw_get_zero_initialized_context();
+  rmw_init_options_t test_options = rmw_get_zero_initialized_init_options();
+  ASSERT_EQ(rmw_init_options_init(&test_options, rcutils_get_default_allocator()), RMW_RET_OK);
+  ASSERT_EQ(rmw_init(&test_options, &test_context), RMW_RET_OK);
+
+  ASSERT_EQ(rmw_uros_check_agent_status(100), RMW_RET_OK);
+
+  ASSERT_EQ(rmw_shutdown(&test_context), RMW_RET_OK);
+
+  ASSERT_EQ(rmw_uros_check_agent_status(100), RMW_RET_ERROR);
+}

--- a/rmw_microxrcedds_c/test/test_rmw.cpp
+++ b/rmw_microxrcedds_c/test/test_rmw.cpp
@@ -46,7 +46,7 @@ TEST(rmw_microxrcedds, autodiscover) {
 /*
    Testing rmw agent check.
 */
-TEST(rmw_microxrcedds, agent_chec_status) {
+TEST(rmw_microxrcedds, agent_check_status) {
   rmw_context_t test_context = rmw_get_zero_initialized_context();
   rmw_init_options_t test_options = rmw_get_zero_initialized_init_options();
   ASSERT_EQ(rmw_init_options_init(&test_options, rcutils_get_default_allocator()), RMW_RET_OK);


### PR DESCRIPTION
This PR adds a function to the direct RMW API to check if the agent is up and ready to interact with the client at a certain moment.

If the no session is created, it returns `RMW_RET_ERROR`
If a session (or multiple ones) is created it check if agent answers to a sync XRCE message successfully.