### PR TITLE
Fix bug on rmw_uxrce_transport_init:custom

### DIFF
--- a/rmw_microxrcedds_c/src/rmw_uros_options.c
+++ b/rmw_microxrcedds_c/src/rmw_uros_options.c
@@ -218,6 +218,12 @@ rmw_ret_t rmw_uros_ping_agent(const int timeout_ms, const uint8_t attempts)
         uxrUDPTransport transport;
 #elif defined(RMW_UXRCE_TRANSPORT_CUSTOM)
         uxrCustomTransport transport;
+        transport.framing  = rmw_uxrce_transport_default_params.framing;
+        transport.args     = rmw_uxrce_transport_default_params.args;
+        transport.open  = rmw_uxrce_transport_default_params.open_cb;
+        transport.close = rmw_uxrce_transport_default_params.close_cb;
+        transport.write = rmw_uxrce_transport_default_params.write_cb;
+        transport.read  = rmw_uxrce_transport_default_params.read_cb;
 #endif
         rmw_ret_t ret = rmw_uxrce_transport_init(NULL, NULL, (void*)&transport);
 

--- a/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
+++ b/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
@@ -15,6 +15,8 @@
 
 #include <rmw/error_handling.h>
 
+#include "./rmw_uros/options.h"
+
 rmw_ret_t rmw_uxrce_transport_init(
     rmw_context_impl_t* context_impl,
     rmw_init_options_impl_t* init_options_impl,
@@ -124,7 +126,9 @@ rmw_ret_t rmw_uxrce_transport_init(
     uxrCustomTransport* custom_transport = (NULL == context_impl)
                                            ? (uxrCustomTransport*)transport
                                            : &context_impl->transport;
-    void* args = init_options_impl->transport_params.args;
+    void* args = (NULL == context_impl)
+                 ? rmw_uxrce_transport_default_params.args
+                 : init_options_impl->transport_params.args;
 
     if (!uxr_init_custom_transport(custom_transport, args))
     {

--- a/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
+++ b/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
@@ -27,7 +27,8 @@ rmw_ret_t rmw_uxrce_transport_init(
                                 ? RMW_UXRCE_DEFAULT_SERIAL_DEVICE
                                 : init_options_impl->transport_params.serial_device;
 
-    if (0 < (int fd = open(serial_device, O_RDWR | O_NOCTTY)))
+    int fd;
+    if (0 < (fd = open(serial_device, O_RDWR | O_NOCTTY)))
     {
         struct termios tty_config;
         memset(&tty_config, 0, sizeof(tty_config));

--- a/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
+++ b/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
@@ -127,7 +127,7 @@ rmw_ret_t rmw_uxrce_transport_init(
                                            ? (uxrCustomTransport*)transport
                                            : &context_impl->transport;
     void* args = (NULL == context_impl)
-                 ? custom_transport->args
+                 ? rmw_uxrce_transport_default_params.args
                  : init_options_impl->transport_params.args;
 
     if (!uxr_init_custom_transport(custom_transport, args))

--- a/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
+++ b/rmw_microxrcedds_c/src/rmw_uxrce_transports.c
@@ -127,7 +127,7 @@ rmw_ret_t rmw_uxrce_transport_init(
                                            ? (uxrCustomTransport*)transport
                                            : &context_impl->transport;
     void* args = (NULL == context_impl)
-                 ? rmw_uxrce_transport_default_params.args
+                 ? custom_transport->args
                  : init_options_impl->transport_params.args;
 
     if (!uxr_init_custom_transport(custom_transport, args))


### PR DESCRIPTION
CI currently does not check custom transport, verify this using a real application on a board