### PR TITLE
Fix bug on time sync test

### DIFF
--- a/rmw_microxrcedds_c/test/test_rmw.cpp
+++ b/rmw_microxrcedds_c/test/test_rmw.cpp
@@ -80,7 +80,9 @@ TEST(rmw_microxrcedds, sync_session)
 
     std::time_t timestamp_seconds = std::time(nullptr);
     ASSERT_EQ(rmw_uros_sync_session(&result_ns, 500), RMW_RET_OK);
-    ASSERT_GE(result_ns / 1000000000, timestamp_seconds);
+
+    int64_t time_diff = abs(result_ns / 1000000000 - timestamp_seconds);
+    ASSERT_LE(time_diff, 5);
 
     ASSERT_EQ(rmw_shutdown(&test_context), RMW_RET_OK);
 }

--- a/rmw_microxrcedds_c/test/test_rmw.cpp
+++ b/rmw_microxrcedds_c/test/test_rmw.cpp
@@ -80,7 +80,7 @@ TEST(rmw_microxrcedds, sync_session)
 
     std::time_t timestamp_seconds = std::time(nullptr);
     ASSERT_EQ(rmw_uros_sync_session(&result_ns, 500), RMW_RET_OK);
-    ASSERT_EQ(result_ns / 1000000000, timestamp_seconds);
+    ASSERT_GE(result_ns / 1000000000, timestamp_seconds);
 
     ASSERT_EQ(rmw_shutdown(&test_context), RMW_RET_OK);
 }


### PR DESCRIPTION
Solve test case error for seconds change on sync:
Assert timestamp retrieved is greater or equal to previous timestamp.