### PR TITLE
move synchronized state to new api

### DIFF
--- a/rmw_microxrcedds_c/include/rmw_uros/options.h
+++ b/rmw_microxrcedds_c/include/rmw_uros/options.h
@@ -59,10 +59,15 @@ typedef struct rmw_uxrce_transport_params_t
 
 
 /**
+ * \brief Returns the time synchronization state of the epoch time.
+ * \return true if last time synchronization succeded and false otherwise
+ */
+bool rmw_uros_epoch_synchronized();
+
+/**
  * \brief Returns the epoch time in milliseconds taking into account the offset computed during the time synchronization.
  * \return epoch time in milliseconds.
  * \return 0 if session is not initialized.
- * \return -1 if session time is not synchronized.
  */
 int64_t rmw_uros_epoch_millis();
 
@@ -70,7 +75,6 @@ int64_t rmw_uros_epoch_millis();
  * \brief Returns the epoch time in nanoseconds taking into account the offset computed during the time synchronization.
  * \return epoch time in nanoseconds.
  * \return 0 if session is not initialized.
- * \return -1 if session time is not synchronized.
  */
 int64_t rmw_uros_epoch_nanos();
 

--- a/rmw_microxrcedds_c/src/rmw_uros_options.c
+++ b/rmw_microxrcedds_c/src/rmw_uros_options.c
@@ -28,6 +28,20 @@
 #include <uxr/client/util/ping.h>
 #include <uxr/client/util/time.h>
 
+bool rmw_uros_epoch_synchronized()
+{
+    // Check session is initialized
+    if (NULL == session_memory.allocateditems)
+    {
+        RMW_SET_ERROR_MSG("Uninitialized session.");
+        return false;
+    }
+    rmw_uxrce_mempool_item_t* item = session_memory.allocateditems;
+    rmw_context_impl_t* context = (rmw_context_impl_t*)item->data;
+
+    return context->session.synchronized;
+}
+
 int64_t rmw_uros_epoch_millis()
 {
     // Check session is initialized
@@ -39,12 +53,6 @@ int64_t rmw_uros_epoch_millis()
 
     rmw_uxrce_mempool_item_t* item = session_memory.allocateditems;
     rmw_context_impl_t* context = (rmw_context_impl_t*)item->data;
-
-    if (!context->session.synchronized)
-    {
-        RMW_SET_ERROR_MSG("Session time not synchronized");
-        return -1;
-    }
 
     return uxr_epoch_millis(&context->session);
 }
@@ -60,12 +68,6 @@ int64_t rmw_uros_epoch_nanos()
 
     rmw_uxrce_mempool_item_t* item = session_memory.allocateditems;
     rmw_context_impl_t* context = (rmw_context_impl_t*)item->data;
-
-    if (!context->session.synchronized)
-    {
-        RMW_SET_ERROR_MSG("Session time not synchronized");
-        return -1;
-    }
 
     return uxr_epoch_nanos(&context->session);
 }
@@ -84,7 +86,6 @@ rmw_ret_t rmw_uros_sync_session(
 
     rmw_uxrce_mempool_item_t* item = session_memory.allocateditems;
     rmw_context_impl_t* context = (rmw_context_impl_t*)item->data;
-    context->session.synchronized = false;
 
     if (!uxr_sync_session(&context->session, timeout_ms))
     {


### PR DESCRIPTION
If the synchronization attempt failed it is not possible to retrieve the epoch time until the next successful synchronization. 
so i think the synchronization should be a separate API call